### PR TITLE
Solve a typo on variables for inventory example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ sap_hana_ha_pacemaker_hana_sid: RH1
 sap_hana_ha_pacemaker_hana_instance_number: "00"
 sap_hana_ha_pacemaker_vip: 192.168.47.100
 sap_hana_ha_pacemaker_hacluster_password: "Mysecretpassword"
-sap_hana_ha_pacemaker_hacluster_node1_fqdn: hana-node1.test.local
-sap_hana_ha_pacemaker_hacluster_node2_fqdn: hana-node2.test.local
-sap_hana_ha_pacemaker_hacluster_node1_ip: 192.168.47.21
-sap_hana_ha_pacemaker_hacluster_node2_ip: 192.168.47.22
+sap_hana_ha_pacemaker_node1_fqdn: hana-node1.test.local
+sap_hana_ha_pacemaker_node2_fqdn: hana-node2.test.local
+sap_hana_ha_pacemaker_node1_ip: 192.168.47.21
+sap_hana_ha_pacemaker_node2_ip: 192.168.47.22
 
 ## License
 

--- a/tasks/cluster-config.yml
+++ b/tasks/cluster-config.yml
@@ -29,7 +29,7 @@
 - name: Authenticate the cluster Nodes
   command: |
     pcs host auth \
-    {{ sap_hana_ha_pacemaker_hacluster_node1_fqdn }} {{ sap_hana_ha_pacemaker_hacluster_node2_fqdn }} \
+    {{ sap_hana_ha_pacemaker_node1_fqdn }} {{ sap_hana_ha_pacemaker_node2_fqdn }} \
     -u hacluster -p {{ sap_hana_ha_pacemaker_hacluster_password }}
   register: auth_cluster
   changed_when: "'Authorized' in auth_cluster.stdout"
@@ -37,9 +37,9 @@
 - name: Create RHEL HA Cluster
   command: |
     pcs cluster setup \
-    {{ sap_hana_ha_pacemaker_hacluster_cluster_name }} \
-    {{ sap_hana_ha_pacemaker_hacluster_node1_fqdn }} \
-    {{ sap_hana_ha_pacemaker_hacluster_node2_fqdn }} \
+    {{ sap_hana_ha_pacemaker_cluster_name }} \
+    {{ sap_hana_ha_pacemaker_node1_fqdn }} \
+    {{ sap_hana_ha_pacemaker_node2_fqdn }} \
   register: create_cluster
   changed_when: "'Cluster has been successfully set up' in create_cluster.stdout"
   run_once: true


### PR DESCRIPTION
There is a typo on some variables used to define the example inventory that needs to be solved