### PR TITLE
Updates for Pacemaker 2/RHEL8.4

### DIFF
--- a/tasks/cluster-config.yml
+++ b/tasks/cluster-config.yml
@@ -28,7 +28,7 @@
 
 - name: Authenticate the cluster Nodes
   command: |
-    pcs {{ _subject }} auth --force \
+    pcs {{ _subject }} auth \
     {{ sap_hana_ha_pacemaker_node1_fqdn }} {{ sap_hana_ha_pacemaker_node2_fqdn }} \
     -u hacluster -p {{ sap_hana_ha_pacemaker_hacluster_password }}
   register: auth_cluster

--- a/tasks/cluster-config.yml
+++ b/tasks/cluster-config.yml
@@ -38,7 +38,7 @@
 
 - name: Create RHEL HA Cluster
   command: |
-    pcs cluster setup --name {{ sap_hana_ha_pacemaker_cluster_name }} \
+    pcs cluster setup {{ sap_hana_ha_pacemaker_cluster_name }} \
     {{ sap_hana_ha_pacemaker_node1_fqdn }} \
     {{ sap_hana_ha_pacemaker_node2_fqdn }} \
   register: create_cluster

--- a/tasks/cluster-resources.yml
+++ b/tasks/cluster-resources.yml
@@ -57,7 +57,7 @@
 - name: Create Cluster constraint
   shell: |
     pcs constraint order SAPHanaTopology_{{ sap_hana_ha_pacemaker_hana_sid }}_{{ sap_hana_ha_pacemaker_hana_instance_number }}-clone  \
-    then SAPHana_{{ sap_hana_ha_pacemaker_hana_sid }}_{{ sap_hana_ha_pacemaker_hana_instance_number }}-master symmetrical=false
+    then SAPHana_{{ sap_hana_ha_pacemaker_hana_sid }}_{{ sap_hana_ha_pacemaker_hana_instance_number }}-clone symmetrical=false
   register: create_constraint
   changed_when: "'Adding SAPHanaTopology' in create_constraint.stdout"
   run_once: true
@@ -65,7 +65,7 @@
 - name: Colocate Cluster constraint
   shell: |
     pcs constraint colocation add vip_{{ sap_hana_ha_pacemaker_hana_sid }}_{{ sap_hana_ha_pacemaker_hana_instance_number }} \
-    with master SAPHana_{{ sap_hana_ha_pacemaker_hana_sid }}_{{ sap_hana_ha_pacemaker_hana_instance_number }}-master 2000
+    with master SAPHana_{{ sap_hana_ha_pacemaker_hana_sid }}_{{ sap_hana_ha_pacemaker_hana_instance_number }}-clone 2000
   register: colocate_constraint
   changed_when: "'error' not in colocate_constraint.stdout"
   run_once: true

--- a/tasks/cluster-resources.yml
+++ b/tasks/cluster-resources.yml
@@ -41,7 +41,7 @@
     op monitor interval=59 role="Master" timeout=700 \
     op promote timeout=3600 \
     op demote timeout=3600 \
-    master notify=true clone-max=2 clone-node-max=1 interleave=true
+    promotable notify=true clone-max=2 clone-node-max=1 interleave=true
   register: create_resource
   changed_when: "'Assumed agent name' in create_resource.stdout"
   run_once: true

--- a/tasks/software-setup.yml
+++ b/tasks/software-setup.yml
@@ -6,5 +6,4 @@
       - resource-agents-sap-hana
       - pcs
       - pacemaker
-      - fence-agents-all
     state: present


### PR DESCRIPTION
Updating a few flags and removing some depreciated options across the cluster creation and resource configuration tasks.

Tested on: RHEL8.4
```
kernel.x86_64                                                         4.18.0-305.10.2.el8_4                       @rhel-8-for-x86_64-baseos-e4s-rpms
kernel-core.x86_64                                                    4.18.0-305.10.2.el8_4                       @rhel-8-for-x86_64-baseos-e4s-rpms
kernel-modules.x86_64                                                 4.18.0-305.10.2.el8_4                       @rhel-8-for-x86_64-baseos-e4s-rpms
kernel-tools.x86_64                                                   4.18.0-305.10.2.el8_4                       @rhel-8-for-x86_64-baseos-e4s-rpms
kernel-tools-libs.x86_64                                              4.18.0-305.10.2.el8_4                       @rhel-8-for-x86_64-baseos-e4s-rpms
pacemaker.x86_64                                                      2.0.5-9.el8                                 @rhel-8-for-x86_64-highavailability-e4s-rpms
pacemaker-cli.x86_64                                                  2.0.5-9.el8                                 @rhel-8-for-x86_64-highavailability-e4s-rpms
pacemaker-cluster-libs.x86_64                                         2.0.5-9.el8                                 @rhel-8-for-x86_64-appstream-e4s-rpms
pacemaker-libs.x86_64                                                 2.0.5-9.el8                                 @rhel-8-for-x86_64-appstream-e4s-rpms
pacemaker-schemas.noarch                                              2.0.5-9.el8                                 @rhel-8-for-x86_64-appstream-e4s-rpms
pcs.x86_64                                                            0.10.8-1.el8                                @rhel-8-for-x86_64-highavailability-e4s-rpms
```

Also removed installing fencing-agents until this role has fencing added